### PR TITLE
Magento: Fix artifact_path generation

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -229,8 +229,8 @@ set('artifact_dir', 'artifacts');
 set('artifact_excludes_file', 'artifacts/excludes');
 
 set('artifact_path', function () {
-    if (!test('[ -d {{artifact_dir}} ]')) {
-        run('mkdir {{artifact_dir}}');
+    if (!testLocally('[ -d {{artifact_dir}} ]')) {
+        runLocally('mkdir -p {{artifact_dir}}');
     }
     return get('artifact_dir') . '/' . get('artifact_file');
 });


### PR DESCRIPTION
- Fix 1. Add -p parameter to mkdir command

    {{artifact_path}} could be configured with multiple folders such as build/artifacts
- Fix 2. run() -> runLocally()

  The {{artifact_dir}} is used to keep artifacts archive file. It should be called at CI server only and not at target server. Then the task `artifact:upload` uploads this file at target server host under {{release_path}}. It is not needed to have {{artifact_dir}} at target server.
