### PR TITLE
Magento: Do not disable maintenance mode after failed deployment

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -303,8 +303,6 @@ task('deploy', [
     'deploy:publish',
 ]);
 
-after('deploy:failed', 'magento:maintenance:disable');
-
 // artifact deployment section
 // settings section
 set('artifact_file', 'artifact.tar.gz');


### PR DESCRIPTION
A failed deployment is likely not in a usuable state. Also if it failed because of missing bin/magento, this command will also fail and the the process stops before deploy:unlock can be executed

- [x] Bug fix #…?
- [ ] New feature?
- [x] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
