### PR TITLE
Cachetool: prevent empty values for sockets

### DIFF
--- a/contrib/cachetool.php
+++ b/contrib/cachetool.php
@@ -81,7 +81,7 @@ set('cachetool:sockets', function() {
     // Socket via path
     if (has('cachetool:socket:glob') && get('cachetool:socket:glob') !== '') {
         $socketPathGlob = get('cachetool:socket:glob');
-        return explode(PHP_EOL, run("ls {$socketPathGlob}"));
+        return array_filter(explode(PHP_EOL, run("ls {$socketPathGlob}")));
     }
     return [];
 });


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
